### PR TITLE
oadrDistributeEvent response + createdEvent function

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "fast-xml-parser": "^3.12.12",
     "jsonix": "^2.4.1",
     "node-webcrypto-ossl": "^1.0.39",
-    "node-webcrypto-p11": "^2.0.2",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
     "uuid": "^3.3.2",


### PR DESCRIPTION
- I had to uncomment the call to model_builder in oadrCreatePartyRegistration because of xmlSignature config. Indeed the only way to configure xmlSignature profile is by adding "xmlSignature:true" to createPartyRegistration payload. the line:
xmlSignature = config.xmlSignature || false;
at node-red module initialization is useless because there is no xmlSignature configuration at node level (node-red UI).

- I added a proper oadr response when a oadrDistributeEvent payload is pushed from VTN to VEN

- I changed the createdEvent function to support pull/push profile

- I changed "responseCode" default value in different payload because this variable is supposed to be a string

- I removed an unused dependency from package.json (node-webcrypto-p11)

- I executed eslint over the code using this command: eslint ./oadr2/ --fix which seems to have done what I expected (code indent etc...). However I'm not used to eslint so don't hesitate to specify the workflow you prefer regarding that point. Maybe this should be scripted as "npm run" cmd in package.json file.